### PR TITLE
feat: add directoryPatterns for colocation support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,19 @@
 export { checkProject } from "./core/project.js";
 export { collectImports } from "./core/import-collector.js";
-export { loadRules } from "./rules/loader.js";
-export { resolveRules } from "./rules/resolver.js";
+export { loadRules, loadRulesForDirectoryWithAllDirs } from "./rules/loader.js";
+export { resolveRules, resolveRulesWithPatterns } from "./rules/resolver.js";
 export { evaluate } from "./evaluator/index.js";
+export {
+	matchDirectoryPattern,
+	findMatchingPatterns,
+	collectPatternSources,
+} from "./rules/pattern-matcher.js";
 
 export type { ImportInfo, ProjectOptions } from "./core/types.js";
-export type { ZoneFenceConfig, ImportRule } from "./rules/types.js";
+export type {
+	ZoneFenceConfig,
+	ImportRule,
+	DirectoryPatternRule,
+	PatternRuleConfig,
+} from "./rules/types.js";
 export type { EvaluationResult, Violation } from "./evaluator/types.js";

--- a/src/rules/colocation.e2e.test.ts
+++ b/src/rules/colocation.e2e.test.ts
@@ -1,0 +1,61 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { loadRulesForDirectoryWithAllDirs } from "./loader.js";
+import { resolveRulesWithPatterns } from "./resolver.js";
+
+const FIXTURE_PATH = path.resolve(__dirname, "../../test-fixtures/colocation/src/pages");
+
+describe("Colocation E2E", () => {
+	it("should load rules with directoryPatterns", async () => {
+		const { rules } = await loadRulesForDirectoryWithAllDirs(FIXTURE_PATH);
+
+		expect(rules[FIXTURE_PATH]).toBeDefined();
+		expect(rules[FIXTURE_PATH].config.directoryPatterns).toHaveLength(2);
+	});
+
+	it("should apply patterns to descendant directories", async () => {
+		const { rules, allDirectories } = await loadRulesForDirectoryWithAllDirs(FIXTURE_PATH);
+		const resolved = resolveRulesWithPatterns(rules, allDirectories);
+
+		// Find all container rules
+		const containerRules = resolved.filter((r) => r.directory.endsWith("/containers"));
+		expect(containerRules.length).toBeGreaterThanOrEqual(2);
+
+		for (const rule of containerRules) {
+			expect(rule.appliedPatternRules).toBeDefined();
+			expect(rule.appliedPatternRules?.some((p) => p.pattern === "**/containers")).toBe(true);
+
+			// Check that the pattern rules are applied
+			expect(rule.config.imports?.allow).toContainEqual({ from: "../presenters/**" });
+			expect(rule.config.imports?.deny).toContainEqual({
+				from: "../containers/**",
+				message: "Containers should not import from sibling containers",
+			});
+		}
+
+		// Find all presenter rules
+		const presenterRules = resolved.filter((r) => r.directory.endsWith("/presenters"));
+		expect(presenterRules.length).toBeGreaterThanOrEqual(2);
+
+		for (const rule of presenterRules) {
+			expect(rule.appliedPatternRules).toBeDefined();
+			expect(rule.appliedPatternRules?.some((p) => p.pattern === "**/presenters")).toBe(true);
+
+			// Check that the pattern rules are applied
+			expect(rule.config.imports?.deny).toContainEqual({
+				from: "../containers/**",
+				message: "Presenters should not import from containers",
+			});
+		}
+	});
+
+	it("should inherit parent scope.exclude patterns", async () => {
+		const { rules, allDirectories } = await loadRulesForDirectoryWithAllDirs(FIXTURE_PATH);
+		const resolved = resolveRulesWithPatterns(rules, allDirectories);
+
+		// All resolved rules should have the exclude pattern from parent
+		for (const rule of resolved) {
+			expect(rule.excludePatterns).toContain("**/*.test.tsx");
+		}
+	});
+});

--- a/src/rules/pattern-matcher.test.ts
+++ b/src/rules/pattern-matcher.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+	calculateSpecificity,
+	collectPatternSources,
+	findMatchingPatterns,
+	matchDirectoryPattern,
+} from "./pattern-matcher.js";
+
+describe("matchDirectoryPattern", () => {
+	it("should match simple pattern", () => {
+		expect(
+			matchDirectoryPattern("/root/pages/home/containers", "**/containers", "/root/pages"),
+		).toBe(true);
+	});
+
+	it("should match nested pattern", () => {
+		expect(
+			matchDirectoryPattern("/root/pages/settings/containers", "**/containers", "/root/pages"),
+		).toBe(true);
+	});
+
+	it("should not match outside source directory", () => {
+		expect(matchDirectoryPattern("/root/api/containers", "**/containers", "/root/pages")).toBe(
+			false,
+		);
+	});
+
+	it("should not match the source directory itself", () => {
+		expect(matchDirectoryPattern("/root/pages", "**/pages", "/root/pages")).toBe(false);
+	});
+
+	it("should match single wildcard pattern", () => {
+		expect(
+			matchDirectoryPattern("/root/pages/home/presenters", "*/presenters", "/root/pages"),
+		).toBe(true);
+	});
+
+	it("should not match deeper nesting with single wildcard", () => {
+		expect(
+			matchDirectoryPattern("/root/pages/home/sub/presenters", "*/presenters", "/root/pages"),
+		).toBe(false);
+	});
+
+	it("should match double wildcard at any depth", () => {
+		expect(
+			matchDirectoryPattern("/root/pages/home/sub/presenters", "**/presenters", "/root/pages"),
+		).toBe(true);
+	});
+});
+
+describe("calculateSpecificity", () => {
+	it("should give higher specificity to literal patterns", () => {
+		const literalSpec = calculateSpecificity("containers");
+		const wildcardSpec = calculateSpecificity("*");
+		expect(literalSpec).toBeGreaterThan(wildcardSpec);
+	});
+
+	it("should give higher specificity to longer literal paths", () => {
+		const longPath = calculateSpecificity("home/containers");
+		const shortPath = calculateSpecificity("containers");
+		expect(longPath).toBeGreaterThan(shortPath);
+	});
+
+	it("should give lower specificity to double wildcards", () => {
+		const doubleWildcard = calculateSpecificity("**/containers");
+		const singleWildcard = calculateSpecificity("*/containers");
+		expect(singleWildcard).toBeGreaterThan(doubleWildcard);
+	});
+});
+
+describe("findMatchingPatterns", () => {
+	it("should find matching patterns and sort by priority", () => {
+		const patternSources = [
+			{
+				sourceFile: "/root/pages/zonefence.yaml",
+				sourceDir: "/root/pages",
+				patterns: [
+					{
+						pattern: "**/containers",
+						config: { description: "Container layer" },
+						priority: 0,
+					},
+					{
+						pattern: "home/containers",
+						config: { description: "Home container layer" },
+						priority: 10,
+					},
+				],
+			},
+		];
+
+		const matches = findMatchingPatterns("/root/pages/home/containers", patternSources);
+
+		expect(matches).toHaveLength(2);
+		// Higher priority first
+		expect(matches[0].pattern).toBe("home/containers");
+		expect(matches[0].priority).toBe(10);
+		expect(matches[1].pattern).toBe("**/containers");
+	});
+
+	it("should return empty array when no patterns match", () => {
+		const patternSources = [
+			{
+				sourceFile: "/root/pages/zonefence.yaml",
+				sourceDir: "/root/pages",
+				patterns: [
+					{
+						pattern: "**/containers",
+						config: { description: "Container layer" },
+						priority: 0,
+					},
+				],
+			},
+		];
+
+		const matches = findMatchingPatterns("/root/api/containers", patternSources);
+
+		expect(matches).toHaveLength(0);
+	});
+
+	it("should sort by specificity when priorities are equal", () => {
+		const patternSources = [
+			{
+				sourceFile: "/root/pages/zonefence.yaml",
+				sourceDir: "/root/pages",
+				patterns: [
+					{
+						pattern: "**/containers",
+						config: { description: "Any containers" },
+						priority: 0,
+					},
+					{
+						pattern: "*/containers",
+						config: { description: "Direct child containers" },
+						priority: 0,
+					},
+				],
+			},
+		];
+
+		const matches = findMatchingPatterns("/root/pages/home/containers", patternSources);
+
+		expect(matches).toHaveLength(2);
+		// More specific pattern (*/containers) should come first
+		expect(matches[0].pattern).toBe("*/containers");
+	});
+});
+
+describe("collectPatternSources", () => {
+	it("should collect patterns from rules with directoryPatterns", () => {
+		const rulesByDirectory = {
+			"/root/pages": {
+				config: {
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: { description: "Container layer" },
+							priority: 0,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+			"/root/api": {
+				config: {},
+				ruleFilePath: "/root/api/zonefence.yaml",
+			},
+		};
+
+		const sources = collectPatternSources(rulesByDirectory);
+
+		expect(sources).toHaveLength(1);
+		expect(sources[0].sourceDir).toBe("/root/pages");
+		expect(sources[0].patterns).toHaveLength(1);
+	});
+
+	it("should return empty array when no patterns defined", () => {
+		const rulesByDirectory = {
+			"/root/pages": {
+				config: {},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+		};
+
+		const sources = collectPatternSources(rulesByDirectory);
+
+		expect(sources).toHaveLength(0);
+	});
+});

--- a/src/rules/pattern-matcher.ts
+++ b/src/rules/pattern-matcher.ts
@@ -1,0 +1,121 @@
+import path from "node:path";
+import { minimatch } from "minimatch";
+import type { DirectoryPatternRule, PatternRuleConfig } from "./types.js";
+
+export interface PatternMatch {
+	pattern: string;
+	config: PatternRuleConfig;
+	priority: number;
+	sourceFile: string;
+	specificity: number;
+}
+
+export interface DirectoryPatternSource {
+	sourceFile: string;
+	sourceDir: string;
+	patterns: DirectoryPatternRule[];
+}
+
+/**
+ * Check if a directory matches a pattern, scoped to the source directory
+ */
+export function matchDirectoryPattern(
+	targetDir: string,
+	pattern: string,
+	sourceDir: string,
+): boolean {
+	const relativePath = path.relative(sourceDir, targetDir);
+
+	// Target must be within source directory (not equal, not outside)
+	if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+		return false;
+	}
+
+	return minimatch(relativePath, pattern, { dot: false });
+}
+
+/**
+ * Calculate the specificity of a pattern (higher = more specific)
+ * More specific patterns should take precedence
+ */
+export function calculateSpecificity(pattern: string): number {
+	let specificity = 0;
+
+	// Count literal path segments (non-wildcard)
+	const segments = pattern.split("/");
+	for (const segment of segments) {
+		if (segment === "**") {
+			// Double wildcard is least specific
+			specificity += 1;
+		} else if (segment === "*") {
+			// Single wildcard is more specific than **
+			specificity += 5;
+		} else if (segment.includes("*")) {
+			// Partial wildcard (e.g., "containers*")
+			specificity += 8;
+		} else {
+			// Literal segment is most specific
+			specificity += 10;
+		}
+	}
+
+	return specificity;
+}
+
+/**
+ * Find all pattern rules that apply to a target directory
+ */
+export function findMatchingPatterns(
+	targetDir: string,
+	patternSources: DirectoryPatternSource[],
+): PatternMatch[] {
+	const matches: PatternMatch[] = [];
+
+	for (const source of patternSources) {
+		for (const rule of source.patterns) {
+			if (matchDirectoryPattern(targetDir, rule.pattern, source.sourceDir)) {
+				matches.push({
+					pattern: rule.pattern,
+					config: rule.config,
+					priority: rule.priority ?? 0,
+					sourceFile: source.sourceFile,
+					specificity: calculateSpecificity(rule.pattern),
+				});
+			}
+		}
+	}
+
+	// Sort by priority (higher first), then by specificity (higher first)
+	matches.sort((a, b) => {
+		if (a.priority !== b.priority) {
+			return b.priority - a.priority;
+		}
+		return b.specificity - a.specificity;
+	});
+
+	return matches;
+}
+
+/**
+ * Collect all directory pattern sources from loaded rules
+ */
+export function collectPatternSources(rulesByDirectory: {
+	[directory: string]: {
+		config: { directoryPatterns?: DirectoryPatternRule[] };
+		ruleFilePath: string;
+	};
+}): DirectoryPatternSource[] {
+	const sources: DirectoryPatternSource[] = [];
+
+	for (const [directory, { config, ruleFilePath }] of Object.entries(rulesByDirectory)) {
+		if (config.directoryPatterns && config.directoryPatterns.length > 0) {
+			sources.push({
+				sourceFile: ruleFilePath,
+				sourceDir: directory,
+				patterns: config.directoryPatterns,
+			});
+		}
+	}
+
+	return sources;
+}

--- a/src/rules/resolver.test.ts
+++ b/src/rules/resolver.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, it } from "vitest";
+import { resolveRules, resolveRulesWithPatterns } from "./resolver.js";
+import type { RulesByDirectory } from "./types.js";
+
+describe("resolveRules with directoryPatterns", () => {
+	it("should apply pattern rules to matching directories", () => {
+		const rulesByDirectory: RulesByDirectory = {
+			"/root/pages": {
+				config: {
+					version: 1,
+					description: "Pages layer",
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: {
+								description: "Container layer",
+								imports: {
+									allow: [{ from: "../presenters/**" }],
+									deny: [{ from: "../containers/**", message: "No sibling imports" }],
+								},
+							},
+							priority: 0,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+			"/root/pages/home/containers": {
+				config: {
+					version: 1,
+				},
+				ruleFilePath: "/root/pages/home/containers/zonefence.yaml",
+			},
+		};
+
+		const resolved = resolveRules(rulesByDirectory);
+
+		const containersRule = resolved.find((r) => r.directory === "/root/pages/home/containers");
+		expect(containersRule).toBeDefined();
+		expect(containersRule?.appliedPatternRules).toHaveLength(1);
+		expect(containersRule?.appliedPatternRules?.[0].pattern).toBe("**/containers");
+		expect(containersRule?.config.imports?.allow).toContainEqual({ from: "../presenters/**" });
+		expect(containersRule?.config.imports?.deny).toContainEqual({
+			from: "../containers/**",
+			message: "No sibling imports",
+		});
+	});
+
+	it("should respect priority when multiple patterns match", () => {
+		const rulesByDirectory: RulesByDirectory = {
+			"/root/pages": {
+				config: {
+					version: 1,
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: {
+								imports: {
+									allow: [{ from: "low-priority" }],
+								},
+							},
+							priority: 0,
+						},
+						{
+							pattern: "home/containers",
+							config: {
+								imports: {
+									allow: [{ from: "high-priority" }],
+								},
+							},
+							priority: 10,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+			"/root/pages/home/containers": {
+				config: { version: 1 },
+				ruleFilePath: "/root/pages/home/containers/zonefence.yaml",
+			},
+		};
+
+		const resolved = resolveRules(rulesByDirectory);
+
+		const containersRule = resolved.find((r) => r.directory === "/root/pages/home/containers");
+		expect(containersRule?.appliedPatternRules).toHaveLength(2);
+		// Both patterns' imports should be merged
+		expect(containersRule?.config.imports?.allow).toContainEqual({ from: "low-priority" });
+		expect(containersRule?.config.imports?.allow).toContainEqual({ from: "high-priority" });
+	});
+
+	it("should give directory's own config highest priority", () => {
+		const rulesByDirectory: RulesByDirectory = {
+			"/root/pages": {
+				config: {
+					version: 1,
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: {
+								description: "Pattern description",
+								imports: {
+									allow: [{ from: "pattern-allow" }],
+								},
+							},
+							priority: 0,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+			"/root/pages/home/containers": {
+				config: {
+					version: 1,
+					description: "Own description",
+					imports: {
+						allow: [{ from: "own-allow" }],
+					},
+				},
+				ruleFilePath: "/root/pages/home/containers/zonefence.yaml",
+			},
+		};
+
+		const resolved = resolveRules(rulesByDirectory);
+
+		const containersRule = resolved.find((r) => r.directory === "/root/pages/home/containers");
+		// Own description takes precedence
+		expect(containersRule?.config.description).toBe("Own description");
+		// But imports should be merged
+		expect(containersRule?.config.imports?.allow).toContainEqual({ from: "pattern-allow" });
+		expect(containersRule?.config.imports?.allow).toContainEqual({ from: "own-allow" });
+	});
+
+	it("should support override merge strategy", () => {
+		const rulesByDirectory: RulesByDirectory = {
+			"/root/pages": {
+				config: {
+					version: 1,
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: {
+								imports: {
+									allow: [{ from: "base-allow" }],
+								},
+							},
+							priority: 0,
+						},
+						{
+							pattern: "home/containers",
+							config: {
+								imports: {
+									allow: [{ from: "override-allow" }],
+								},
+								mergeStrategy: "override",
+							},
+							priority: 10,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+			"/root/pages/home/containers": {
+				config: { version: 1 },
+				ruleFilePath: "/root/pages/home/containers/zonefence.yaml",
+			},
+		};
+
+		const resolved = resolveRules(rulesByDirectory);
+
+		const containersRule = resolved.find((r) => r.directory === "/root/pages/home/containers");
+		// Override should replace, not merge
+		expect(containersRule?.config.imports?.allow).toHaveLength(1);
+		expect(containersRule?.config.imports?.allow).toContainEqual({ from: "override-allow" });
+	});
+});
+
+describe("resolveRulesWithPatterns", () => {
+	it("should create rules for directories that only match patterns", () => {
+		const rulesByDirectory: RulesByDirectory = {
+			"/root/pages": {
+				config: {
+					version: 1,
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: {
+								description: "Container layer",
+								imports: {
+									allow: [{ from: "../presenters/**" }],
+								},
+							},
+							priority: 0,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+		};
+
+		// Simulate directories that exist but don't have their own zonefence.yaml
+		const allDirectories = [
+			"/root/pages",
+			"/root/pages/home",
+			"/root/pages/home/containers",
+			"/root/pages/home/presenters",
+			"/root/pages/settings",
+			"/root/pages/settings/containers",
+		];
+
+		const resolved = resolveRulesWithPatterns(rulesByDirectory, allDirectories);
+
+		// Should have rules for pages + home/containers + settings/containers
+		const containerRules = resolved.filter((r) => r.directory.endsWith("/containers"));
+		expect(containerRules).toHaveLength(2);
+
+		for (const rule of containerRules) {
+			expect(rule.appliedPatternRules).toHaveLength(1);
+			expect(rule.config.imports?.allow).toContainEqual({ from: "../presenters/**" });
+		}
+	});
+
+	it("should not apply patterns outside the source directory scope", () => {
+		const rulesByDirectory: RulesByDirectory = {
+			"/root/pages": {
+				config: {
+					version: 1,
+					directoryPatterns: [
+						{
+							pattern: "**/containers",
+							config: {
+								imports: {
+									allow: [{ from: "pages-pattern" }],
+								},
+							},
+							priority: 0,
+						},
+					],
+				},
+				ruleFilePath: "/root/pages/zonefence.yaml",
+			},
+		};
+
+		const allDirectories = [
+			"/root/pages",
+			"/root/pages/home/containers",
+			"/root/api",
+			"/root/api/containers", // This should NOT match pages' pattern
+		];
+
+		const resolved = resolveRulesWithPatterns(rulesByDirectory, allDirectories);
+
+		const apiContainers = resolved.find((r) => r.directory === "/root/api/containers");
+		// api/containers should not exist in resolved rules (no matching patterns)
+		expect(apiContainers).toBeUndefined();
+
+		const pagesContainers = resolved.find((r) => r.directory === "/root/pages/home/containers");
+		expect(pagesContainers).toBeDefined();
+		expect(pagesContainers?.config.imports?.allow).toContainEqual({ from: "pages-pattern" });
+	});
+});

--- a/src/rules/resolver.ts
+++ b/src/rules/resolver.ts
@@ -1,9 +1,15 @@
 import path from "node:path";
+import {
+	type PatternMatch,
+	collectPatternSources,
+	findMatchingPatterns,
+} from "./pattern-matcher.js";
 import type { ImportRule, ResolvedRule, RulesByDirectory, ZoneFenceConfig } from "./types.js";
 
 export function resolveRules(rulesByDirectory: RulesByDirectory): ResolvedRule[] {
 	const resolvedRules: ResolvedRule[] = [];
 	const directories = Object.keys(rulesByDirectory).sort((a, b) => a.length - b.length);
+	const patternSources = collectPatternSources(rulesByDirectory);
 
 	for (const directory of directories) {
 		const { config, ruleFilePath } = rulesByDirectory[directory];
@@ -12,7 +18,26 @@ export function resolveRules(rulesByDirectory: RulesByDirectory): ResolvedRule[]
 		const parentRules = findParentRules(directory, directories, rulesByDirectory);
 
 		// Merge with parent rules
-		const mergedConfig = mergeConfigs(parentRules, config);
+		let mergedConfig = mergeConfigs(parentRules, config);
+
+		// Apply pattern rules (pattern rules have lower priority than direct zonefence.yaml)
+		const patternMatches = findMatchingPatterns(directory, patternSources);
+		const appliedPatternRules: ResolvedRule["appliedPatternRules"] = [];
+
+		if (patternMatches.length > 0) {
+			// Apply pattern rules first (lowest priority)
+			let patternConfig = createEmptyConfig(mergedConfig.version);
+			for (const match of [...patternMatches].reverse()) {
+				patternConfig = applyPatternRule(patternConfig, match);
+				appliedPatternRules.unshift({
+					pattern: match.pattern,
+					sourceFile: match.sourceFile,
+					priority: match.priority,
+				});
+			}
+			// Then merge with the directory's own config (highest priority)
+			mergedConfig = mergeTwoConfigs(patternConfig, mergedConfig);
+		}
 
 		// Collect exclude patterns
 		const excludePatterns = collectExcludePatterns(mergedConfig);
@@ -22,10 +47,136 @@ export function resolveRules(rulesByDirectory: RulesByDirectory): ResolvedRule[]
 			ruleFilePath,
 			config: mergedConfig,
 			excludePatterns,
+			appliedPatternRules: appliedPatternRules.length > 0 ? appliedPatternRules : undefined,
 		});
 	}
 
 	return resolvedRules;
+}
+
+/**
+ * Resolve rules including directories that only match patterns (no zonefence.yaml)
+ * This scans for directories that match patterns defined in parent zonefence.yaml files
+ */
+export function resolveRulesWithPatterns(
+	rulesByDirectory: RulesByDirectory,
+	allDirectories: string[],
+): ResolvedRule[] {
+	const patternSources = collectPatternSources(rulesByDirectory);
+	const directoriesWithRules = new Set(Object.keys(rulesByDirectory));
+
+	// Find directories that match patterns but don't have their own zonefence.yaml
+	const patternOnlyDirectories: string[] = [];
+	for (const dir of allDirectories) {
+		if (!directoriesWithRules.has(dir)) {
+			const matches = findMatchingPatterns(dir, patternSources);
+			if (matches.length > 0) {
+				patternOnlyDirectories.push(dir);
+			}
+		}
+	}
+
+	// Create a combined rules object with pattern-only directories
+	const combinedRules: RulesByDirectory = { ...rulesByDirectory };
+	for (const dir of patternOnlyDirectories) {
+		const matches = findMatchingPatterns(dir, patternSources);
+		if (matches.length > 0) {
+			// Use the first matching pattern's source file as the rule file path
+			combinedRules[dir] = {
+				config: { version: 1 },
+				ruleFilePath: matches[0].sourceFile,
+			};
+		}
+	}
+
+	// Now resolve all rules (including pattern-only directories)
+	const resolvedRules: ResolvedRule[] = [];
+	const directories = Object.keys(combinedRules).sort((a, b) => a.length - b.length);
+
+	for (const directory of directories) {
+		const { config, ruleFilePath } = combinedRules[directory];
+		const hasOwnConfig = directoriesWithRules.has(directory);
+
+		// Find parent rules
+		const parentRules = findParentRules(directory, directories, combinedRules);
+
+		// Merge with parent rules
+		let mergedConfig = mergeConfigs(parentRules, config);
+
+		// Apply pattern rules
+		const patternMatches = findMatchingPatterns(directory, patternSources);
+		const appliedPatternRules: ResolvedRule["appliedPatternRules"] = [];
+
+		if (patternMatches.length > 0) {
+			// For pattern-only directories, pattern rules are the primary source
+			// For directories with their own config, pattern rules have lower priority
+			let patternConfig = createEmptyConfig(mergedConfig.version);
+			for (const match of [...patternMatches].reverse()) {
+				patternConfig = applyPatternRule(patternConfig, match);
+				appliedPatternRules.unshift({
+					pattern: match.pattern,
+					sourceFile: match.sourceFile,
+					priority: match.priority,
+				});
+			}
+
+			if (hasOwnConfig) {
+				// Directory has its own config - it takes precedence over patterns
+				mergedConfig = mergeTwoConfigs(patternConfig, mergedConfig);
+			} else {
+				// Pattern-only directory - patterns are merged with parent rules
+				mergedConfig = mergeTwoConfigs(mergedConfig, patternConfig);
+			}
+		}
+
+		// Collect exclude patterns
+		const excludePatterns = collectExcludePatterns(mergedConfig);
+
+		resolvedRules.push({
+			directory,
+			ruleFilePath,
+			config: mergedConfig,
+			excludePatterns,
+			appliedPatternRules: appliedPatternRules.length > 0 ? appliedPatternRules : undefined,
+		});
+	}
+
+	return resolvedRules;
+}
+
+function createEmptyConfig(version: number): ZoneFenceConfig {
+	return { version };
+}
+
+function applyPatternRule(base: ZoneFenceConfig, match: PatternMatch): ZoneFenceConfig {
+	const { config } = match;
+	const mergeStrategy = config.mergeStrategy ?? "merge";
+
+	if (mergeStrategy === "override") {
+		// Override: pattern config completely replaces base imports
+		return {
+			...base,
+			description: config.description ?? base.description,
+			imports: config.imports
+				? {
+						allow: config.imports.allow ?? [],
+						deny: config.imports.deny ?? [],
+						mode: config.imports.mode ?? base.imports?.mode ?? "allow-first",
+					}
+				: base.imports,
+		};
+	}
+
+	// Merge (default): combine imports
+	return {
+		...base,
+		description: config.description ?? base.description,
+		imports: {
+			allow: mergeImportRules(base.imports?.allow, config.imports?.allow),
+			deny: mergeImportRules(base.imports?.deny, config.imports?.deny),
+			mode: config.imports?.mode ?? base.imports?.mode ?? "allow-first",
+		},
+	};
 }
 
 function findParentRules(

--- a/src/rules/schema.ts
+++ b/src/rules/schema.ts
@@ -8,6 +8,24 @@ const importRuleSchema = z.union([
 	}),
 ]);
 
+const importsSchema = z.object({
+	allow: z.array(importRuleSchema).optional().default([]),
+	deny: z.array(importRuleSchema).optional().default([]),
+	mode: z.enum(["allow-first", "deny-first"]).optional().default("allow-first"),
+});
+
+const patternRuleConfigSchema = z.object({
+	description: z.string().optional(),
+	imports: importsSchema.optional(),
+	mergeStrategy: z.enum(["merge", "override"]).optional().default("merge"),
+});
+
+const directoryPatternRuleSchema = z.object({
+	pattern: z.string(),
+	config: patternRuleConfigSchema,
+	priority: z.number().int().optional().default(0),
+});
+
 export const zoneFenceConfigSchema = z.object({
 	version: z.number().int().positive(),
 	description: z.string().optional(),
@@ -18,14 +36,8 @@ export const zoneFenceConfigSchema = z.object({
 		})
 		.optional()
 		.default({}),
-	imports: z
-		.object({
-			allow: z.array(importRuleSchema).optional().default([]),
-			deny: z.array(importRuleSchema).optional().default([]),
-			mode: z.enum(["allow-first", "deny-first"]).optional().default("allow-first"),
-		})
-		.optional()
-		.default({}),
+	imports: importsSchema.optional().default({}),
+	directoryPatterns: z.array(directoryPatternRuleSchema).optional().default([]),
 });
 
 export type ParsedZoneFenceConfig = z.infer<typeof zoneFenceConfigSchema>;

--- a/src/rules/types.ts
+++ b/src/rules/types.ts
@@ -1,9 +1,26 @@
 export type ScopeApply = "self" | "descendants";
 export type EvaluationMode = "allow-first" | "deny-first";
+export type MergeStrategy = "merge" | "override";
 
 export interface ImportRule {
 	from: string;
 	message?: string;
+}
+
+export interface PatternRuleConfig {
+	description?: string;
+	imports?: {
+		allow?: ImportRule[];
+		deny?: ImportRule[];
+		mode?: EvaluationMode;
+	};
+	mergeStrategy?: MergeStrategy;
+}
+
+export interface DirectoryPatternRule {
+	pattern: string;
+	config: PatternRuleConfig;
+	priority?: number;
 }
 
 export interface ZoneFenceConfig {
@@ -18,6 +35,7 @@ export interface ZoneFenceConfig {
 		deny?: ImportRule[];
 		mode?: EvaluationMode;
 	};
+	directoryPatterns?: DirectoryPatternRule[];
 }
 
 export interface ResolvedRule {
@@ -29,6 +47,12 @@ export interface ResolvedRule {
 	config: ZoneFenceConfig;
 	/** File patterns to exclude from checking */
 	excludePatterns: string[];
+	/** Pattern rules that were applied to this directory */
+	appliedPatternRules?: {
+		pattern: string;
+		sourceFile: string;
+		priority: number;
+	}[];
 }
 
 export interface RulesByDirectory {

--- a/test-fixtures/colocation/src/pages/home/containers/HomeContainer.tsx
+++ b/test-fixtures/colocation/src/pages/home/containers/HomeContainer.tsx
@@ -1,0 +1,6 @@
+// Valid imports from presenters
+import { HomePresenter } from "../presenters/HomePresenter";
+
+export function HomeContainer() {
+	return <HomePresenter />;
+}

--- a/test-fixtures/colocation/src/pages/home/containers/InvalidContainer.tsx
+++ b/test-fixtures/colocation/src/pages/home/containers/InvalidContainer.tsx
@@ -1,0 +1,6 @@
+// Invalid: importing from sibling containers (should be flagged)
+import { SettingsContainer } from "../../settings/containers/SettingsContainer";
+
+export function InvalidContainer() {
+	return <SettingsContainer />;
+}

--- a/test-fixtures/colocation/src/pages/home/presenters/HomePresenter.tsx
+++ b/test-fixtures/colocation/src/pages/home/presenters/HomePresenter.tsx
@@ -1,0 +1,3 @@
+export function HomePresenter() {
+	return <div>Home</div>;
+}

--- a/test-fixtures/colocation/src/pages/home/presenters/InvalidPresenter.tsx
+++ b/test-fixtures/colocation/src/pages/home/presenters/InvalidPresenter.tsx
@@ -1,0 +1,6 @@
+// Invalid: importing from containers (should be flagged)
+import { HomeContainer } from "../containers/HomeContainer";
+
+export function InvalidPresenter() {
+	return <HomeContainer />;
+}

--- a/test-fixtures/colocation/src/pages/settings/containers/SettingsContainer.tsx
+++ b/test-fixtures/colocation/src/pages/settings/containers/SettingsContainer.tsx
@@ -1,0 +1,6 @@
+// Valid imports from presenters
+import { SettingsPresenter } from "../presenters/SettingsPresenter";
+
+export function SettingsContainer() {
+	return <SettingsPresenter />;
+}

--- a/test-fixtures/colocation/src/pages/settings/presenters/SettingsPresenter.tsx
+++ b/test-fixtures/colocation/src/pages/settings/presenters/SettingsPresenter.tsx
@@ -1,0 +1,3 @@
+export function SettingsPresenter() {
+	return <div>Settings</div>;
+}

--- a/test-fixtures/colocation/src/pages/zonefence.yaml
+++ b/test-fixtures/colocation/src/pages/zonefence.yaml
@@ -1,0 +1,29 @@
+version: 1
+description: "Pages layer rules with colocation patterns"
+
+directoryPatterns:
+  - pattern: "**/containers"
+    config:
+      description: "Container layer"
+      imports:
+        allow:
+          - from: "../presenters/**"
+          - from: "../hooks/**"
+        deny:
+          - from: "../containers/**"
+            message: "Containers should not import from sibling containers"
+
+  - pattern: "**/presenters"
+    config:
+      description: "Presenter layer"
+      imports:
+        allow:
+          - from: "./**"
+          - from: "@/ui/**"
+        deny:
+          - from: "../containers/**"
+            message: "Presenters should not import from containers"
+
+scope:
+  exclude:
+    - "**/*.test.tsx"

--- a/test-fixtures/colocation/tsconfig.json
+++ b/test-fixtures/colocation/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"strict": true,
+		"esModuleInterop": true,
+		"jsx": "react-jsx",
+		"baseUrl": ".",
+		"paths": {
+			"@/*": ["./src/*"]
+		}
+	},
+	"include": ["src/**/*"]
+}


### PR DESCRIPTION
- Add directoryPatterns to zonefence.yaml schema for automatic rule application
- Implement pattern-matcher.ts with minimatch-based directory matching
- Extend loader to return all scanned directories
- Extend resolver with resolveRulesWithPatterns for pattern-only directories
- Support priority and mergeStrategy options
- Add unit tests and E2E tests
- Update README (EN/JA) with documentation