### PR TITLE
fix: apply directoryPatterns to directories without zonefence.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "zonefence",
-	"version": "0.0.9",
+	"version": "0.0.10",
 	"description": "Folder-based architecture guardrails for TypeScript projects",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/src/cli/commands/check.ts
+++ b/src/cli/commands/check.ts
@@ -6,8 +6,8 @@ import { createProject } from "../../core/project.js";
 import { evaluate } from "../../evaluator/index.js";
 import type { PathsMapping } from "../../evaluator/types.js";
 import { reportToConsole } from "../../reporter/console.js";
-import { loadRulesForDirectory } from "../../rules/loader.js";
-import { resolveRules } from "../../rules/resolver.js";
+import { loadRulesForDirectoryWithAllDirs } from "../../rules/loader.js";
+import { resolveRulesWithPatterns } from "../../rules/resolver.js";
 
 export interface CheckOptions {
 	config?: string;
@@ -84,8 +84,8 @@ export async function checkCommand(targetPath: string, options: CheckOptions): P
 			process.exit(0);
 		}
 
-		const rulesByDir = await loadRulesForDirectory(absolutePath);
-		const resolvedRules = resolveRules(rulesByDir);
+		const { rules, allDirectories } = await loadRulesForDirectoryWithAllDirs(absolutePath);
+		const resolvedRules = resolveRulesWithPatterns(rules, allDirectories);
 
 		// Get paths mapping from tsconfig for pattern resolution
 		const pathsMapping = getPathsMapping(project, absolutePath, tsConfigFilePath);


### PR DESCRIPTION
## Summary

- `check`コマンドで`directoryPatterns`が`zonefence.yaml`を持たないディレクトリに適用されない問題を修正
- `loadRulesForDirectory`と`resolveRules`から`loadRulesForDirectoryWithAllDirs`と`resolveRulesWithPatterns`に変更

## Root Cause

`src/cli/commands/check.ts`で使用していた関数が、パターンベースのルールをサポートしていなかった。

## Changes

```diff
- import { loadRulesForDirectory } from "../../rules/loader.js";
- import { resolveRules } from "../../rules/resolver.js";
+ import { loadRulesForDirectoryWithAllDirs } from "../../rules/loader.js";
+ import { resolveRulesWithPatterns } from "../../rules/resolver.js";

- const rulesByDir = await loadRulesForDirectory(absolutePath);
- const resolvedRules = resolveRules(rulesByDir);
+ const { rules, allDirectories } = await loadRulesForDirectoryWithAllDirs(absolutePath);
+ const resolvedRules = resolveRulesWithPatterns(rules, allDirectories);
```

## Test plan

- [x] ビルド成功確認
- [x] 既存テスト全てパス

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)