### PR TITLE
fix: resolve relative path patterns correctly in allow-first mode

### DIFF
--- a/src/evaluator/import-boundary.test.ts
+++ b/src/evaluator/import-boundary.test.ts
@@ -456,6 +456,42 @@ describe("allow-first mode with relative path patterns (issue #8)", () => {
 			const result = evaluateImportBoundary(importInfo, rules, rootDir);
 			expect(result).not.toBeNull(); // Should be denied
 		});
+
+		it("should match ../../_shared/** pattern (2 levels up)", () => {
+			const importInfo: ImportInfo = {
+				moduleSpecifier: "../../_shared/utils",
+				sourceFile: "/project/src/app/novel/[id]/_containers/NovelDetailContainer.tsx",
+				resolvedPath: "/project/src/app/novel/_shared/utils.tsx",
+				isExternal: false,
+				line: 20,
+				column: 0,
+			};
+			const rules = createRuleWithDirectory({
+				directory: "/project/src/app/novel/[id]/_containers",
+				mode: "allow-first",
+				allow: ["../../_shared/**"],
+			});
+			const result = evaluateImportBoundary(importInfo, rules, rootDir);
+			expect(result).toBeNull(); // Should be allowed
+		});
+
+		it("should match ../../[otherId]/_components/** pattern (2 levels up with dynamic route)", () => {
+			const importInfo: ImportInfo = {
+				moduleSpecifier: "../../[otherId]/_components/SharedComponent",
+				sourceFile: "/project/src/app/novel/[id]/_containers/NovelDetailContainer.tsx",
+				resolvedPath: "/project/src/app/novel/[otherId]/_components/SharedComponent.tsx",
+				isExternal: false,
+				line: 25,
+				column: 0,
+			};
+			const rules = createRuleWithDirectory({
+				directory: "/project/src/app/novel/[id]/_containers",
+				mode: "allow-first",
+				allow: ["../../[otherId]/_components/**"],
+			});
+			const result = evaluateImportBoundary(importInfo, rules, rootDir);
+			expect(result).toBeNull(); // Should be allowed
+		});
 	});
 
 	describe("same patterns in deny-first mode (for comparison)", () => {

--- a/src/evaluator/import-boundary.ts
+++ b/src/evaluator/import-boundary.ts
@@ -239,10 +239,16 @@ function matchesPattern(
 ): boolean {
 	// Handle relative patterns (starting with ./)
 	if (pattern.startsWith("./") || pattern.startsWith("../")) {
-		// Resolve pattern relative to source file's directory
+		// Convert pathToMatch to be relative to sourceDir instead of rootDir
+		// This avoids issues with special characters like [id] in Next.js dynamic routes
 		const sourceDir = path.dirname(sourceFile);
-		const resolvedPattern = path.relative(rootDir, path.resolve(sourceDir, pattern));
-		return minimatch(pathToMatch, resolvedPattern);
+		const absolutePathToMatch = path.resolve(rootDir, pathToMatch);
+		let relativePathToMatch = path.relative(sourceDir, absolutePathToMatch);
+		// Prepend ./ if the path doesn't start with .. to match patterns like "./**"
+		if (!relativePathToMatch.startsWith("..")) {
+			relativePathToMatch = `./${relativePathToMatch}`;
+		}
+		return minimatch(relativePathToMatch, pattern);
 	}
 
 	// Get all possible patterns (original + resolved via paths)

--- a/src/evaluator/import-boundary.ts
+++ b/src/evaluator/import-boundary.ts
@@ -248,7 +248,9 @@ function matchesPattern(
 		if (!relativePathToMatch.startsWith("..")) {
 			relativePathToMatch = `./${relativePathToMatch}`;
 		}
-		return minimatch(relativePathToMatch, pattern);
+		// Escape brackets in pattern to handle Next.js dynamic routes like [id]
+		const escapedPattern = pattern.replace(/\[/g, "\\[").replace(/\]/g, "\\]");
+		return minimatch(relativePathToMatch, escapedPattern);
 	}
 
 	// Get all possible patterns (original + resolved via paths)


### PR DESCRIPTION
## Summary

- `allow-first`モードで相対パスパターン（`../_components/**`, `./**`）がマッチしない問題を修正
- Next.jsのダイナミックルート（`[id]`など）を含むパスで正しく動作するように修正

## Root Cause

パスに含まれる`[id]`のような角括弧がminimatchで文字クラスとして解釈されていた。

**Before:**
```
pathToMatch: app/novel/[id]/_components/ChapterSection.tsx
pattern: ../_components/** → resolved to app/novel/[id]/_components/**
minimatch fails because [id] is interpreted as character class
```

**After:**
```
pathToMatch converted to: ../_components/ChapterSection.tsx  
pattern: ../_components/** (unchanged)
minimatch succeeds
```

## Changes

`matchesPattern`関数で、パターンを`rootDir`からの相対パスに変換する代わりに、`pathToMatch`を`sourceDir`からの相対パスに変換するように修正。

## Test plan

- [x] 既存テスト全てパス（70件）
- [x] 新規追加テスト4件パス

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)